### PR TITLE
Config filenames can contain hyphens

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -76,7 +76,7 @@ impl ConfigurationStore {
             bail!(Error::ConfigurationStoreNotFound(configurations_path));
         }
 
-        let file_name_regex = Regex::new(r"^config_[a-zA-Z0-9]+$").unwrap();
+        let file_name_regex = Regex::new(r"^config_[a-zA-Z0-9-]+$").unwrap();
         let mut configurations: HashMap<String, Configuration> = HashMap::new();
 
         for file in fs::read_dir(&configurations_path)? {


### PR DESCRIPTION
I had my configurations setup with names like `foo-bar`and gctx would not list them in list mode. Checked the output of the gcloud config configurations validation and it accepts hyphens in the name as well as alpha-numeric.